### PR TITLE
Light level management

### DIFF
--- a/automation.yaml
+++ b/automation.yaml
@@ -38,12 +38,14 @@ automation:
           - input_select.ambientika_1_mode
           - input_number.ambientika_1_fanspeed
           - input_number.ambientika_1_humiditylevel
+          - input_number.ambientika_1_lightlevel
         id: change_mode
       - platform: state
         entity_id:
           - sensor.ambientika_1_operating_mode
           - sensor.ambientika_1_fan_speed
           - sensor.ambientika_1_humidity_level
+          - sensor.ambientika_1_lightsensor_level
         id: mode_changed
     condition:
       - condition: template
@@ -62,6 +64,7 @@ automation:
                   mode: '"{{ states("input_select.ambientika_1_mode") }}"'
                   fan: "{{ states('input_number.ambientika_1_fanSpeed')|int - 1 }}"
                   humidity: "{{ states('input_number.ambientika_1_humidityLevel')|int - 1 }}"
+                  light: "{{ states('input_number.ambientika_1_lightLevel')|int - 1 }}"
               - delay:
                   hours: 0
                   minutes: 0
@@ -79,7 +82,8 @@ automation:
                 value_template:
                   "{{ states('sensor.ambientika_1_operating_mode') not in ['unavailable', 'unknown'] and
                   states('sensor.ambientika_1_fan_speed') not in ['unavailable', 'unknown'] and
-                  states('sensor.ambientika_1_humidity_level') not in ['unavailable', 'unknown'] }}"
+                  states('sensor.ambientika_1_humidity_level') not in ['unavailable', 'unknown'] and
+                  states('sensor.ambientika_1_lightsensor_level') not in ['unavailable', 'unknown'] }}"
             sequence:
               - action: input_select.select_option
                 target:
@@ -99,6 +103,13 @@ automation:
                     {% elif states('sensor.ambientika_1_humidity_level') == 'Moist' %} 3
                     {% else %} {{ states('input_number.ambientika_1_humiditylevel') }}
                     {% endif %}"
+                  lightsensorlevel:
+                    "{% if states('sensor.ambientika_1_lightsensor_level') == 'NotAvailable' %} 1
+                    {% if states('sensor.ambientika_1_lightsensor_level') == 'Off' %} 2
+                    {% elif states('sensor.ambientika_1_lightsensor_level') == 'Low' %} 3
+                    {% elif states('sensor.ambientika_1_lightsensor_level') == 'Medium' %} 4
+                    {% else %} {{ states('input_number.ambientika_1_lightlevel') }}
+                    {% endif %}"
               - action: input_number.set_value
                 target:
                   entity_id: input_number.ambientika_1_fanspeed
@@ -109,6 +120,11 @@ automation:
                   entity_id: input_number.ambientika_1_humiditylevel
                 data:
                   value: "{{ humiditylevel|float }}"
+              - action: input_number.set_value
+                target:
+                  entity_id: input_number.ambientika_1_lightlevel
+                data:
+                  value: "{{ lightsensorlevel|float }}"
 
   - id: automation.ambientika_1_filter_notification
     alias: Ambientika 1 Filter Notification

--- a/helpers.yaml
+++ b/helpers.yaml
@@ -19,6 +19,13 @@ input_number:
     max: 3
     step: 1
     icon: mdi:water
+  ambientika_1_lightsensorlevel:
+    name: Ambientika 1 Light-Level
+    options:
+    min: 1
+    max: 4
+    step: 1
+    icon: mdi:theme-light-dark
 
 input_select:
   ambientika_1_mode:

--- a/rest_commands.yaml
+++ b/rest_commands.yaml
@@ -14,7 +14,7 @@ rest_command:
       accept: "application/json"
       Authorization: >
         Bearer {{ states("input_text.ambientika_access_token") }}
-    payload: '{"deviceSerialNumber":"{{ serial }}","operatingMode":{{ mode }},"fanSpeed":{{ fan }},"humidityLevel":{{ humidity }}}'
+    payload: '{"deviceSerialNumber":"{{ serial }}","operatingMode":{{ mode }},"fanSpeed":{{ fan }},"humidityLevel":{{ humidity }},"lightSensorLevel":{{ light }}}'
     content_type: "application/json"
 
   ambientika_reset_filter:

--- a/sensors.yaml
+++ b/sensors.yaml
@@ -63,7 +63,16 @@ rest:
       - unique_id: ambientika_1_lightSensorLevel
         value_template: "{{ value_json.lightSensorLevel | is_defined }}"
         name: Ambientika 1 Light-Sensor
-        icon: mdi:theme-light-dark
+        icon: >-
+          {% if states('sensor.ambientika_1_lightsensor_level') == 'NotAvailable' %}
+          mdi:weather-sunny-alert
+          {% if states('sensor.ambientika_1_lightsensor_level') == 'Off' %}
+          mdi:track-light-off
+          {% elif states('sensor.ambientika_1_lightsensor_level') == 'Low' %}
+          mdi:brightness-4
+          {% elif states('sensor.ambientika_1_lightsensor_level') == 'Medium' %}
+          mdi:brightness-6
+          {% else %} mdi:fan-alert {% endif %}
       - unique_id: ambientika_1_signalStrenght
         value_template: "{{ value_json.signalStrenght | is_defined }}"
         name: Ambientika 1 Signal

--- a/switch.yaml
+++ b/switch.yaml
@@ -15,6 +15,7 @@ switch:
               mode: '"{{ states("input_select.ambientika_1_mode") }}"'
               fan: "{{ states('input_number.ambientika_1_fanSpeed')|int - 1 }}"
               humidity: "{{ states('input_number.ambientika_1_humidityLevel')|int - 1 }}"
+              light: "{{ states('input_number.ambientika_1_lightLevel')|int - 1 }}"
           - delay: "00:00:03"
           - service: homeassistant.update_entity
             target:
@@ -27,6 +28,7 @@ switch:
               mode: '"Off"'
               fan: "{{ states('input_number.ambientika_1_fanSpeed')|int - 1 }}"
               humidity: "{{ states('input_number.ambientika_1_humidityLevel')|int - 1 }}"
+              light: "{{ states('input_number.ambientika_1_lightLevel')|int - 1 }}"
           - delay: "00:00:03"
           - service: homeassistant.update_entity
             target:


### PR DESCRIPTION
refering #13 , here is a first draft.

I am not sure if it is the correct implementation because i had this kind of error in the log:

2025-01-19 18:25:18.825 ERROR (MainThread) [homeassistant.components.automation.ambientika_chambre_change_mode] Error while executing automation automation.ambientika_chambre_change_mode: Error rendering data template: ValueError: Template error: int got invalid input 'unknown' when rendering template '{{ states('input_number.ambientika_chambre_lightlevel')|int - 1 }}' but no default was specified

Following this forum:
https://community.home-assistant.io/t/template-warning-int-got-invalid-input/393484/2

Since I changed this  "int - 1" by  "int(2)" I have a good answer but Ambientika behavior is not Ok to me.

2025-01-20 20:42:02.909 DEBUG (MainThread) [homeassistant.components.rest_command] Success. Url: https://app.ambientika.eu:4521/device/change-mode. Status code: 200. Payload: b'{"deviceSerialNumber":"XXXXXXXXXX","operatingMode":"Auto","fanSpeed":3,"humidityLevel":1,"lightSensorLevel":2}'

Maybe you could have a look on this.

Cheers
